### PR TITLE
vLan support use of v2 Auth tokens

### DIFF
--- a/docker-compose.devmode.yml
+++ b/docker-compose.devmode.yml
@@ -1,10 +1,10 @@
 version: '3'
 services:
-  vlab-vlan-api:
+  vlan-api:
     volumes:
       - ./vlab_vlan:/usr/lib/python3.6/site-packages/vlab_vlan
     command: ["python3", "app.py"]
-  vlab-vlan-celery:
+  vlan-worker:
     volumes:
       - ./vlab_vlan:/usr/lib/python3.6/site-packages/vlab_vlan
     command: ["celery", "-A", "tasks", "worker", "--loglevel", "debug"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,28 @@
 version: '3'
 services:
-  vlab-vlan-api:
+  vlan-api:
     image:
       willnx/vlab-vlan-api
     ports:
       - "5000:5000"
     sysctls:
       - net.core.somaxconn=500
-  vlab-vlan-db:
+  vlan-db:
     image:
       willnx/vlab-vlan-db
     environment:
       - VLAB_VLAN_ID_MIN=100
       - VLAB_VLAN_ID_MAX=4000
       - POSTGRES_PASSWORD=testing
-  vlab-vlan-celery:
+  vlan-worker:
     image:
-      willnx/vlab-vlan-celery
+      willnx/vlab-vlan-worker
     environment:
       - POSTGRES_PASSWORD=testing
       - INF_VCENTER_SERVER=localhost
       - INF_VCENTER_USER=changeMe
       - INF_VCENTER_PASSWORD=changeMe
       - INF_VCENTER_TOP_LVL_DIR=/vlab
-  vlab-vlan-rabbit:
+  vlan-broker:
     image:
       rabbitmq:3.7-alpine

--- a/vlab_vlan/lib/views/vlan.py
+++ b/vlab_vlan/lib/views/vlan.py
@@ -47,7 +47,7 @@ class VlanView(TaskView):
                       ]
                     }
 
-    @requires(verify=False)
+    @requires(verify=False, version=(1,2))
     @describe(post=POST_SCHEMA, delete=DELETE_SCHEMA, get_args={})
     def get(self, *args, **kwargs):
         """Obtain a info about the vlans a user owns"""
@@ -57,7 +57,7 @@ class VlanView(TaskView):
         resp['content'] = {'task-id': task.id}
         return ujson.dumps(resp), 200
 
-    @requires(verify=False) # XXX remove verify=False before commit
+    @requires(verify=False, version=(1,2)) # XXX remove verify=False before commit
     @validate_input(schema=POST_SCHEMA)
     def post(self, *args, **kwargs):
         """Create a new vlan"""
@@ -66,7 +66,7 @@ class VlanView(TaskView):
         switch_name = kwargs['body']['switch-name']
         return _dispatch_modify(username=username, the_task='vlan.create', vlan_name=vlan_name, switch_name=switch_name)
 
-    @requires(verify=False) # XXX remove verify=False before commit
+    @requires(verify=False, version=(1,2)) # XXX remove verify=False before commit
     @validate_input(schema=DELETE_SCHEMA)
     def delete(self, *args, **kwargs):
         """Delete a lvan"""


### PR DESCRIPTION
I also fixed an issue with standing up a local dev instance of the service. Seems like when I updated vLan to comply with the naming convention of the other vLab services, I forgot to update the names in the docker-compose files.