### PR TITLE
Fixed server error when deleting network that is in use

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-vlan",
       author="Nicholas Willhite",
       author_email='willnx84@gmail.com',
-      version='2018.11.30',
+      version='2018.12.31',
       packages=find_packages(),
       include_package_data=True,
       package_files={'vlab_switches' : ['app.ini']},

--- a/tests/test_vmware.py
+++ b/tests/test_vmware.py
@@ -52,7 +52,7 @@ class TestVMware(unittest.TestCase):
     @patch.object(vmware, 'vCenter')
     def test_delete_network_in_use(self, fake_vCenter, fake_consume_task):
         """vmware - ``delete_network`` raises ValueError if the vLAN is still being used by VMs"""
-        fake_consume_task.side_effect = [vmware.vim.fault.ResourceInUse()]
+        fake_consume_task.side_effect = [RuntimeError()]
 
         with self.assertRaises(ValueError):
             vmware.delete_network(name='someNetwork')

--- a/vlab_vlan/lib/worker/vmware.py
+++ b/vlab_vlan/lib/worker/vmware.py
@@ -59,8 +59,8 @@ def delete_network(name):
         try:
             task = network.Destroy_Task()
             consume_task(task, timeout=300)
-        except vim.fault.ResourceInUse:
-            msg = "Unable to delete vLAN when Virtual Machines(es) are configured to use it"
+        except RuntimeError:
+            msg = "Network {} in use. Must delete VMs using network before deleting network.".format(name)
             raise ValueError(msg)
 
 


### PR DESCRIPTION
The worker was catching the wrong exception, which lead to a SERVER ERROR when a user requested to delete a network that is in use by a VM.
Now it catches the correct error, which will result in an HTTP 400 response.