### PR TITLE
container will now exit if unable to load app

### DIFF
--- a/ApiDockerfile
+++ b/ApiDockerfile
@@ -5,4 +5,4 @@ COPY dist/*.whl /tmp
 RUN pip install /tmp/*.whl && rm /tmp/*.whl
 RUN apk del gcc
 WORKDIR /usr/lib/python3.6/site-packages/vlab_vlan
-CMD uwsgi --ini ./app.ini
+CMD uwsgi --need-app --ini ./app.ini


### PR DESCRIPTION
This update fixes a race that can occur between the Auth Service and the apps that need to query the Auth Service for the token verification key:

![image](https://user-images.githubusercontent.com/12264343/50699423-aa9b7200-0ffc-11e9-91c0-541b582319f4.png)
