### PR TITLE
no longer using ephemeral dvPortGroups

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-vlan",
       author="Nicholas Willhite",
       author_email='willnx84@gmail.com',
-      version='2019.02.18',
+      version='2019.03.18',
       packages=find_packages(),
       include_package_data=True,
       package_files={'vlab_switches' : ['app.ini']},

--- a/vlab_vlan/lib/worker/vmware.py
+++ b/vlab_vlan/lib/worker/vmware.py
@@ -80,7 +80,7 @@ def get_dv_portgroup_spec(name, vlan_id):
     spec = vim.dvs.DistributedVirtualPortgroup.ConfigSpec()
     spec.name = name
 
-    spec.type = vim.dvs.DistributedVirtualPortgroup.PortgroupType.ephemeral
+    spec.type = vim.dvs.DistributedVirtualPortgroup.PortgroupType.earlyBinding
 
     spec.defaultPortConfig = vim.dvs.VmwareDistributedVirtualSwitch.VmwarePortConfigPolicy()
     spec.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec()
@@ -91,5 +91,6 @@ def get_dv_portgroup_spec(name, vlan_id):
     spec.defaultPortConfig.securityPolicy.allowPromiscuous = vim.BoolPolicy(value=True)
     spec.defaultPortConfig.securityPolicy.macChanges = vim.BoolPolicy(value=False)
     spec.defaultPortConfig.securityPolicy.inherited = False
+    print(spec)
 
     return spec


### PR DESCRIPTION
While setting up the prod vCenter server, I noticed that the max limits on ephemeral dvPortGroups is significantly lower than a auto-expanding static dvPortGroup

https://configmax.vmware.com/guest

With the limit of 1016 ephemeral portgroups per dvSwitch, the production server would max out with ~500 users. So instead of dealing with that gnarly issue in the future, switching to the auto-expanding type of switch will have zero issues scaling because they max out at 60,000 portgroups.