### PR TITLE
Username on VLAN is a server-side thing now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-vlan",
       author="Nicholas Willhite",
       author_email='willnx84@gmail.com',
-      version='2019.06.1',
+      version='2019.06.24',
       packages=find_packages(),
       include_package_data=True,
       package_files={'vlab_switches' : ['app.ini']},

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -41,6 +41,15 @@ class TestDatabase(unittest.TestCase):
         """Runs after every test case"""
         cls.fake_psycopg2_connect.stop()
 
+    def test_get_vlan_strip_name(self):
+        """database - ``get_vlan`` strips the username off the vLAN name"""
+        self.fake_cur.fetchall.return_value = [('alice_smith_vlanA', 100)]
+
+        result = database.get_vlan(username='alice_smith')
+        expected = {'vlanA': 100}
+
+        self.assertEqual(result, expected)
+
     def test_get_db_connection(self):
         """database - ``get_db_connection`` returns the connection and cursor"""
         conn, cur = database.get_db_connection()

--- a/tests/test_vlan_view.py
+++ b/tests/test_vlan_view.py
@@ -36,8 +36,8 @@ class TestVlanView(unittest.TestCase):
 
     @patch.object(flask_common, 'logger')
     def test_get_task_id(self, fake_logger):
-        """VlanView - GET on /api/1/inf/vlan returns a task-id"""
-        resp = self.app.get('/api/1/inf/vlan',
+        """VlanView - GET on /api/2/inf/vlan returns a task-id"""
+        resp = self.app.get('/api/2/inf/vlan',
                             headers={'X-Auth': self.token})
 
         task_id = resp.json['content']['task-id']
@@ -47,8 +47,8 @@ class TestVlanView(unittest.TestCase):
 
     @patch.object(flask_common, 'logger')
     def test_get_status_coded(self, fake_logger):
-        """VlanView - GET on /api/1/inf/vlan returns HTTP 202"""
-        resp = self.app.get('/api/1/inf/vlan',
+        """VlanView - GET on /api/2/inf/vlan returns HTTP 202"""
+        resp = self.app.get('/api/2/inf/vlan',
                             headers={'X-Auth': self.token})
 
         status = resp.status_code
@@ -58,19 +58,19 @@ class TestVlanView(unittest.TestCase):
 
     @patch.object(flask_common, 'logger')
     def test_get_link(self, fake_logger):
-        """VlanView - GET on /api/1/inf/vlan sets the Link header"""
-        resp = self.app.get('/api/1/inf/vlan',
+        """VlanView - GET on /api/2/inf/vlan sets the Link header"""
+        resp = self.app.get('/api/2/inf/vlan',
                             headers={'X-Auth': self.token})
 
         link = resp.headers['Link']
-        expected = '<https://localhost/api/1/inf/vlan/task/asdf-asdf-asdf>; rel=status'
+        expected = '<https://localhost/api/2/inf/vlan/task/asdf-asdf-asdf>; rel=status'
 
         self.assertEqual(link, expected)
 
     @patch.object(flask_common, 'logger')
     def test_post_task_id(self, fake_logger):
-        """VlanView - POST on /api/1/inf/vlan returns a task-id"""
-        resp = self.app.post('/api/1/inf/vlan',
+        """VlanView - POST on /api/2/inf/vlan returns a task-id"""
+        resp = self.app.post('/api/2/inf/vlan',
                              json={'switch-name': 'SomeSwitch', 'vlan-name': 'NewVLAN'},
                              headers={'X-Auth': self.token})
 
@@ -81,8 +81,8 @@ class TestVlanView(unittest.TestCase):
 
     @patch.object(flask_common, 'logger')
     def test_post_status_code(self, fake_logger):
-        """VlanView - POST on /api/1/inf/vlan returns HTTP 202"""
-        resp = self.app.post('/api/1/inf/vlan',
+        """VlanView - POST on /api/2/inf/vlan returns HTTP 202"""
+        resp = self.app.post('/api/2/inf/vlan',
                              json={'switch-name': 'SomeSwitch', 'vlan-name': 'NewVLAN'},
                              headers={'X-Auth': self.token})
 
@@ -93,8 +93,8 @@ class TestVlanView(unittest.TestCase):
 
     @patch.object(flask_common, 'logger')
     def test_post_switch_name_required(self, fake_logger):
-        """VlanView - POST on /api/1/inf/vlan returns HTTP 400 if switch-name not supplied"""
-        resp = self.app.post('/api/1/inf/vlan',
+        """VlanView - POST on /api/2/inf/vlan returns HTTP 400 if switch-name not supplied"""
+        resp = self.app.post('/api/2/inf/vlan',
                              json={'vlan-name': 'NewVLAN'},
                              headers={'X-Auth': self.token})
 
@@ -105,8 +105,8 @@ class TestVlanView(unittest.TestCase):
 
     @patch.object(flask_common, 'logger')
     def test_post_vlan_name_required(self, fake_logger):
-        """VlanView - POST on /api/1/inf/vlan returns HTTP 400 if vlan-name not supplied"""
-        resp = self.app.post('/api/1/inf/vlan',
+        """VlanView - POST on /api/2/inf/vlan returns HTTP 400 if vlan-name not supplied"""
+        resp = self.app.post('/api/2/inf/vlan',
                              json={'switch-name': 'SomeSwitch'},
                              headers={'X-Auth': self.token})
 
@@ -117,21 +117,21 @@ class TestVlanView(unittest.TestCase):
 
     @patch.object(flask_common, 'logger')
     def test_post_link(self, fake_logger):
-        """VlanView - POST on /api/1/inf/vlan sets the Link header"""
-        resp = self.app.post('/api/1/inf/vlan',
+        """VlanView - POST on /api/2/inf/vlan sets the Link header"""
+        resp = self.app.post('/api/2/inf/vlan',
                              json={'switch-name': 'SomeSwitch', 'vlan-name': 'NewVLAN'},
                              headers={'X-Auth': self.token})
 
         status_code = resp.status_code
         link = resp.headers['Link']
-        expected = '<https://localhost/api/1/inf/vlan/task/asdf-asdf-asdf>; rel=status'
+        expected = '<https://localhost/api/2/inf/vlan/task/asdf-asdf-asdf>; rel=status'
 
         self.assertEqual(link, expected)
 
     @patch.object(flask_common, 'logger')
     def test_delete_task_id(self, fake_logger):
-        """VlanView - DELETE on /api/1/inf/vlan returns a task-id"""
-        resp = self.app.delete('/api/1/inf/vlan',
+        """VlanView - DELETE on /api/2/inf/vlan returns a task-id"""
+        resp = self.app.delete('/api/2/inf/vlan',
                              json={'vlan-name': 'NewVLAN'},
                              headers={'X-Auth': self.token})
 
@@ -142,8 +142,8 @@ class TestVlanView(unittest.TestCase):
 
     @patch.object(flask_common, 'logger')
     def test_delete_status_code(self, fake_logger):
-        """VlanView - DELETE on /api/1/inf/vlan returns HTTP 202"""
-        resp = self.app.delete('/api/1/inf/vlan',
+        """VlanView - DELETE on /api/2/inf/vlan returns HTTP 202"""
+        resp = self.app.delete('/api/2/inf/vlan',
                              json={'vlan-name': 'NewVLAN'},
                              headers={'X-Auth': self.token})
 
@@ -154,8 +154,8 @@ class TestVlanView(unittest.TestCase):
 
     @patch.object(flask_common, 'logger')
     def test_delete_vlan_name_required(self, fake_logger):
-        """VlanView - DELETE on /api/1/inf/vlan returns HTTP 400 if vlan-name not supplied"""
-        resp = self.app.delete('/api/1/inf/vlan',
+        """VlanView - DELETE on /api/2/inf/vlan returns HTTP 400 if vlan-name not supplied"""
+        resp = self.app.delete('/api/2/inf/vlan',
                              json={},
                              headers={'X-Auth': self.token})
 
@@ -166,16 +166,26 @@ class TestVlanView(unittest.TestCase):
 
     @patch.object(flask_common, 'logger')
     def test_delete_link(self, fake_logger):
-        """VlanView - DELETE on /api/1/inf/vlan sets the Link header"""
-        resp = self.app.delete('/api/1/inf/vlan',
+        """VlanView - DELETE on /api/2/inf/vlan sets the Link header"""
+        resp = self.app.delete('/api/2/inf/vlan',
                              json={'vlan-name': 'NewVLAN'},
                              headers={'X-Auth': self.token})
 
         link = resp.headers['Link']
-        expected = '<https://localhost/api/1/inf/vlan/task/asdf-asdf-asdf>; rel=status'
+        expected = '<https://localhost/api/2/inf/vlan/task/asdf-asdf-asdf>; rel=status'
 
         self.assertEqual(link, expected)
 
+    @patch.object(flask_common, 'logger')
+    def test_v1_404(self, fake_logger):
+        """VlanView - GET on /api/1/inf/vlan returns HTTP 404"""
+        resp = self.app.get('/api/1/inf/vlan',
+                            headers={'X-Auth': self.token})
+
+        status = resp.status_code
+        expected = 404
+
+        self.assertEqual(status, expected)
 
 if __name__ == '__main__':
     unittest.main()

--- a/vlab_vlan/lib/views/vlan.py
+++ b/vlab_vlan/lib/views/vlan.py
@@ -16,7 +16,7 @@ logger = get_logger(__name__, loglevel=const.VLAB_VLAN_LOG_LEVEL)
 
 class VlanView(TaskView):
     """Defines the HTTP API for working with virtual local area networks"""
-    route_base = '/api/1/inf/vlan'
+    route_base = '/api/2/inf/vlan'
     POST_SCHEMA = { "$schema": "http://json-schema.org/draft-04/schema#",
                     "type": "object",
                     "properties": {
@@ -66,7 +66,7 @@ class VlanView(TaskView):
     def post(self, *args, **kwargs):
         """Create a new vlan"""
         username = kwargs['token']['username']
-        vlan_name = kwargs['body']['vlan-name']
+        vlan_name = '{}_{}'.format(username, kwargs['body']['vlan-name'])
         switch_name = kwargs['body']['switch-name']
         txn_id = request.headers.get('X-REQUEST-ID', 'noId')
         resp_data, task_id =  _dispatch_modify(username=username,
@@ -84,7 +84,7 @@ class VlanView(TaskView):
     def delete(self, *args, **kwargs):
         """Delete a lvan"""
         username = kwargs['token']['username']
-        vlan_name = kwargs['body']['vlan-name']
+        vlan_name = '{}_{}'.format(username, kwargs['body']['vlan-name'])
         txn_id = request.headers.get('X-REQUEST-ID', 'noId')
         resp_data, task_id = _dispatch_modify(username=username,
                                               the_task='vlan.delete',

--- a/vlab_vlan/lib/worker/database.py
+++ b/vlab_vlan/lib/worker/database.py
@@ -125,11 +125,12 @@ def get_vlan(username):
     """
     # Order of vlan_name, tag matters
     get_sql = """SELECT vlan_name, tag FROM records WHERE person LIKE %s;"""
+    NAME_TAG = '{}_'.format(username) # Networks in VMware has the user's name added to them
     conn, cur = get_db_connection()
     try:
         cur.execute(get_sql, (username,))
         # x[0] should be the vlan name, x[1] should be the tag id
-        result = {x[0]:x[1] for x in cur.fetchall()}
+        result = {x[0].replace(NAME_TAG, ''):x[1] for x in cur.fetchall()}
     finally:
         conn.close()
     return result


### PR DESCRIPTION
Adding/remove the username to the vLan is now controlled server-side.

This has been _long overdue_, and this change helps to enforce network isolation between labs.
All services that can create a VM also need to be updated before this issue is completely resolved.