### PR TITLE
Usernames are no longer stripped in database module

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -41,12 +41,12 @@ class TestDatabase(unittest.TestCase):
         """Runs after every test case"""
         cls.fake_psycopg2_connect.stop()
 
-    def test_get_vlan_strip_name(self):
-        """database - ``get_vlan`` strips the username off the vLAN name"""
+    def test_get_vlan_no_strip_name(self):
+        """database - ``get_vlan`` does not strip the username off the vLAN name"""
         self.fake_cur.fetchall.return_value = [('alice_smith_vlanA', 100)]
 
         result = database.get_vlan(username='alice_smith')
-        expected = {'vlanA': 100}
+        expected = {'alice_smith_vlanA': 100}
 
         self.assertEqual(result, expected)
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -22,6 +22,16 @@ class TestTasks(unittest.TestCase):
 
     @patch.object(tasks, 'get_task_logger')
     @patch.object(tasks, 'database')
+    def test_list_strips(self, fake_database, fake_get_task_logger):
+        """tasks - ``list`` strips off the username tag before returning the response"""
+        fake_database.get_vlan.return_value = {'bob_myVlan' : 1234}
+        result = tasks.list(username='bob', txn_id='myId')
+        expected =  {'content': {'myVlan': 1234}, 'params': {}, 'error': None}
+
+        self.assertEqual(result, expected)
+
+    @patch.object(tasks, 'get_task_logger')
+    @patch.object(tasks, 'database')
     @patch.object(tasks, 'delete_network')
     def test_delete(self, fake_delete_network, fake_database, fake_get_task_logger):
         """tasks - ``delete`` destroys the defined vLAN returns a dictionary"""

--- a/vlab_vlan/lib/worker/database.py
+++ b/vlab_vlan/lib/worker/database.py
@@ -125,12 +125,11 @@ def get_vlan(username):
     """
     # Order of vlan_name, tag matters
     get_sql = """SELECT vlan_name, tag FROM records WHERE person LIKE %s;"""
-    NAME_TAG = '{}_'.format(username) # Networks in VMware has the user's name added to them
     conn, cur = get_db_connection()
     try:
         cur.execute(get_sql, (username,))
         # x[0] should be the vlan name, x[1] should be the tag id
-        result = {x[0].replace(NAME_TAG, ''):x[1] for x in cur.fetchall()}
+        result = {x[0]:x[1] for x in cur.fetchall()}
     finally:
         conn.close()
     return result

--- a/vlab_vlan/lib/worker/tasks.py
+++ b/vlab_vlan/lib/worker/tasks.py
@@ -51,7 +51,12 @@ def list(self, username, txn_id):
     logger = get_task_logger(txn_id=txn_id, task_id=self.request.id, loglevel=const.VLAB_VLAN_LOG_LEVEL.upper())
     resp = {'content' : {}, 'error' : None, 'params' : {}}
     logger.info('Task Starting')
-    resp['content'] = database.get_vlan(username)
+    USER_TAG = '{}_'.format(username)
+    vlans = database.get_vlan(username)
+    answer = {}
+    for name, tag in vlans.items():
+        answer[name.replace(USER_TAG, '')] = tag
+    resp['content'] = answer
     logger.info('Task Completed')
     return resp
 


### PR DESCRIPTION
I knew there would be bugs! So glad I manually started testing this stuff.

Turns out, the DB module should not strip off the names because tasks assume literal values.
Instead, given that this is purely cosmetic for the user, just strip it off within the task when answering _"Hey, what networks do I have?"_